### PR TITLE
chore: added check for firstname/lastname when matching user

### DIFF
--- a/src/Services/Individual/IndividualService.cs
+++ b/src/Services/Individual/IndividualService.cs
@@ -37,6 +37,9 @@ namespace verint_service.Services.Individual
             if (customer.Address != null)
                 customer.Address.UPRN = await _propertyService.CheckUPRNForId(customer.Address);
 
+            if(string.IsNullOrEmpty(customer.Forename) || string.IsNullOrEmpty(customer.Surname))
+                return await CreateAsync(customer);
+
             var individual = await FindAsync(customer);
 
             if (individual == null)
@@ -199,7 +202,6 @@ namespace verint_service.Services.Individual
 
             var results = await Task.WhenAll(tasks);
             _logger.LogDebug($"IndividualService.GetBestMatchingAsync Retrieved all search result objects, Customer: {customer.Surname}");
-            results = RemoveNonMatchingForenameAndSurname(results, customer);
 
             results.ToList().ForEach(result =>
             {
@@ -223,21 +225,6 @@ namespace verint_service.Services.Individual
             }
 
             return bestMatchingObjectID;
-        }
-
-        private retrieveIndividualResponse[] RemoveNonMatchingForenameAndSurname(retrieveIndividualResponse[] results, Customer customer)
-        {
-            if(results == null)
-                return results;
-
-            results = results.ToList()
-                .Where(_ => _.FWTIndividual.Name != null)
-                .Where(_ => _.FWTIndividual.Name.Any(_ => _.Surname != null && _.Forename.Any(x => x != null)))
-                .Where(_ => _.FWTIndividual.Name.Any(_ => _.Surname.Trim().ToLower().Equals(customer.Surname.Trim().ToLower())))
-                .Where(_ => _.FWTIndividual.Name.Any(_ => _.Forename.Any(_ => _.Trim().ToLower().Equals(customer.Forename.Trim().ToLower()))))
-                .ToArray();
-
-            return results;
         }
     }
 }

--- a/src/Services/Individual/IndividualService.cs
+++ b/src/Services/Individual/IndividualService.cs
@@ -199,6 +199,7 @@ namespace verint_service.Services.Individual
 
             var results = await Task.WhenAll(tasks);
             _logger.LogDebug($"IndividualService.GetBestMatchingAsync Retrieved all search result objects, Customer: {customer.Surname}");
+            results = RemoveNonMatchingForenameAndSurname(results, customer);
 
             results.ToList().ForEach(result =>
             {
@@ -222,6 +223,21 @@ namespace verint_service.Services.Individual
             }
 
             return bestMatchingObjectID;
+        }
+
+        private retrieveIndividualResponse[] RemoveNonMatchingForenameAndSurname(retrieveIndividualResponse[] results, Customer customer)
+        {
+            if(results == null)
+                return results;
+
+            results = results.ToList()
+                .Where(_ => _.FWTIndividual.Name != null)
+                .Where(_ => _.FWTIndividual.Name.Any(_ => _.Surname != null && _.Forename.Any(x => x != null)))
+                .Where(_ => _.FWTIndividual.Name.Any(_ => _.Surname.Trim().ToLower().Equals(customer.Surname.Trim().ToLower())))
+                .Where(_ => _.FWTIndividual.Name.Any(_ => _.Forename.Any(_ => _.Trim().ToLower().Equals(customer.Forename.Trim().ToLower()))))
+                .ToArray();
+
+            return results;
         }
     }
 }

--- a/tests/Services/IndividualServiceTests.cs
+++ b/tests/Services/IndividualServiceTests.cs
@@ -4,7 +4,6 @@ using Microsoft.Extensions.Logging;
 using Moq;
 using StockportGovUK.NetStandard.Models.Verint;
 using verint_service.Helpers.VerintConnection;
-using verint_service.Services;
 using verint_service.Services.Individual;
 using verint_service.Services.Individual.Weighting;
 using verint_service.Services.Property;
@@ -44,7 +43,7 @@ namespace verint_service_tests.Services
         {
             // Arrange
              _mockIndividualWeighting.Setup(_ => _.Calculate(It.IsAny<FWTIndividual>(), It.IsAny<Customer>()))
-                .Returns(2);
+                .Returns(1);
 
             var userSearchResponse = new FWTObjectBriefDetails 
             {
@@ -55,9 +54,11 @@ namespace verint_service_tests.Services
                 .ReturnsAsync(new searchForPartyResponse{ FWTObjectBriefDetailsList = new FWTObjectBriefDetails[1]{ userSearchResponse } });
 
             _mockClient.Setup(_ => _.retrieveIndividualAsync(It.IsAny<FWTObjectID>()))
-                .ReturnsAsync(new retrieveIndividualResponse{ FWTIndividual = new FWTIndividual { BriefDetails = new FWTObjectBriefDetails { ObjectID = new FWTObjectID() } } });
+                .ReturnsAsync(new retrieveIndividualResponse{ FWTIndividual = new FWTIndividual { BriefDetails = new FWTObjectBriefDetails { ObjectID = new FWTObjectID() }, Name = new FWTIndividualName[1] { new FWTIndividualName { Surname = "surname", Forename = new string[1] { "forename" } } } } });
 
             var customer = new CustomerBuilder()
+                .WithForename("forename")
+                .WithSurname("surname")
                 .Build();
             
             // Act
@@ -75,7 +76,7 @@ namespace verint_service_tests.Services
             // Arrange
              _mockIndividualWeighting.SetupSequence(_ => _.Calculate(It.IsAny<FWTIndividual>(), It.IsAny<Customer>()))
                 .Returns(0)
-                .Returns(2);
+                .Returns(1);
 
             var userSearchResponse = new FWTObjectBriefDetails 
             {
@@ -86,9 +87,11 @@ namespace verint_service_tests.Services
                 .ReturnsAsync(new searchForPartyResponse{ FWTObjectBriefDetailsList = new FWTObjectBriefDetails[1]{ userSearchResponse } });
 
             _mockClient.Setup(_ => _.retrieveIndividualAsync(It.IsAny<FWTObjectID>()))
-                .ReturnsAsync(new retrieveIndividualResponse{ FWTIndividual = new FWTIndividual { BriefDetails = new FWTObjectBriefDetails { ObjectID = new FWTObjectID() } } });
+                .ReturnsAsync(new retrieveIndividualResponse{ FWTIndividual = new FWTIndividual { BriefDetails = new FWTObjectBriefDetails { ObjectID = new FWTObjectID() }, Name = new FWTIndividualName[1] { new FWTIndividualName { Surname = "last", Forename = new string[1] { "first" } } } } });
 
             var customer = new CustomerBuilder()
+                .WithForename("first")
+                .WithSurname("last")
                 .WithEmail("email@test.com")
                 .Build();
             


### PR DESCRIPTION
### Description
Added check to MatchAsync to not perform partySearch if forename or surname has not been supplied.


### Checklist
- [x] Code compiles correctly
- [x] Created tests for the new changes
- [x] All tests passing
- [x] Extended the README / documentation, if necessary