### PR TITLE
fix(caseservice): fixed LogDebug not logging exception message

### DIFF
--- a/src/Services/Case/CaseService.cs
+++ b/src/Services/Case/CaseService.cs
@@ -107,7 +107,7 @@ namespace verint_service.Services.Case
             }
             catch(Exception ex)
             {
-                _logger.LogError($"CaseService.Create:{crmCase.ID} Verint create case failed", ex);
+                _logger.LogError(ex, $"CaseService.Create:{crmCase.ID} Verint create case failed");
                 throw new Exception($"CaseService.Create:{crmCase.ID} Verint create case failed", ex);
             }
         }


### PR DESCRIPTION
### Description
Fixed logger.LogError within CaseService passing exception as object agrs so exception was being swallowed and not logged, Moved exception to first params to log exception with message.


### Checklist
- [x] Code compiles correctly
- [x] Created tests for the new changes
- [x] All tests passing
- [x] Extended the README / documentation, if necessary